### PR TITLE
Prevent duplicate strategy injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # liu-algotrader-docker
+
+This repository provides a Docker-based setup for running Liu Algo Trader and
+helper scripts.  The `engine-wrapper/fix_it_bot.py` tool can modify
+`liu_samples/tradeplan.toml` by injecting a data block and a sample strategy.
+
+If you want to restore the original trade plan, copy the clean sample provided
+in `liu_samples/tradeplan.sample.toml` back to `tradeplan.toml`:
+
+```bash
+cp liu_samples/tradeplan.sample.toml liu_samples/tradeplan.toml
+```
+

--- a/engine-wrapper/fix_it_bot.py
+++ b/engine-wrapper/fix_it_bot.py
@@ -31,8 +31,11 @@ def inject_sections(tp: Path):
         to_add += "\n" + DATA_BLOCK
     else:
         print("🔍 [data] already present.")
-    print("✨ Appending strategy block.")
-    to_add += "\n" + STRAT_BLOCK
+    if "mean_reversion_auto" not in text:
+        print("✨ Appending strategy block.")
+        to_add += "\n" + STRAT_BLOCK
+    else:
+        print("🔍 mean_reversion strategy already present.")
     tp.write_text(text + to_add)
 
 def run_backtest(args):

--- a/liu_samples/tradeplan.sample.toml
+++ b/liu_samples/tradeplan.sample.toml
@@ -1,0 +1,53 @@
+# -----------------------------------------------------------------------------
+# Liu Algo Trader backtest configuration (tradeplan.toml)
+# -----------------------------------------------------------------------------
+
+# Which events to listen for (you can trim this if you don’t need quotes/trades)
+events = ["second", "minute", "trade", "quote"]
+
+# -----------------------------------------------------------------------------
+# Portfolio & risk settings
+# -----------------------------------------------------------------------------
+# Total buying power for this run
+portfolio_value = 25000.0
+
+# Fraction of portfolio to risk per trade (e.g. 0.001 = 0.1%)
+risk = 0.001
+
+# How many minutes before market close to force liquidation
+market_liquidation_end_time_minutes = 15
+
+# If true, only scanners will run (no orders)—useful for debugging
+# test_scanners = true
+
+# -----------------------------------------------------------------------------
+# Default symbols (override with --symbols if you like)
+# -----------------------------------------------------------------------------
+symbols = ["AAPL", "MSFT", "GOOG", "NVDA", "TSLA", "META"]
+
+# -----------------------------------------------------------------------------
+# Scanner definitions (array of tables)
+# -----------------------------------------------------------------------------
+[[scanners]]
+name             = "momentum"
+provider         = "alpaca"
+min_volume       = 1        # minimum volume since day open
+min_gap          = 0.0          # minimum % gap from previous close
+min_last_dv      = 0       # minimum last-day dollar volume
+min_share_price  = 0.0          # skip under-$2 stocks
+max_share_price  = 9999.0         # skip over-$20 stocks
+from_market_open = 0           # wait N minutes after open before scanning
+recurrence       = 5            # re-run scanner every N minutes
+
+# -----------------------------------------------------------------------------
+# Strategy definitions (array of tables)
+# -----------------------------------------------------------------------------
+[[strategies]]
+filename = "momentum_long_simplified.py"
+
+# Each strategy can have one or more schedules (array of tables)
+[[strategies.schedule]]
+start    = 15    # minutes after open to begin running this strategy
+duration = 60    # how many minutes to keep running it
+
+


### PR DESCRIPTION
## Summary
- avoid injecting the `mean_reversion_auto` strategy block twice
- ship a clean example `tradeplan.toml`
- document how to restore the sample tradeplan

## Testing
- `python3 -m py_compile engine-wrapper/fix_it_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685470729a8883319e107986ff1f9a5c